### PR TITLE
Make JSON.stringify's formatting and replacing capabilities available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ const data = {foo: 'bar'}
 console.log(safeJsonStringify(data));
 ```
 
+All the parameters of `JSON.stringify` are accepted, try e.g. the following for a nicely formatted output:
+
+```js
+console.log(safeJsonStringify(data, null, 2));
+```
+
 An `ensureProperties` function is exposed too, which returns a safe object without the stringify step. Usage: `safeJsonStringify.ensureProperties(data);`.
 
 

--- a/index.js
+++ b/index.js
@@ -52,8 +52,8 @@ function ensureProperties(obj) {
 	return visit(obj);
 }
 
-module.exports = function(data) {
-	return JSON.stringify(ensureProperties(data));
+module.exports = function(data, replacer, space) {
+	return JSON.stringify(ensureProperties(data), replacer, space);
 }
 
 module.exports.ensureProperties = ensureProperties;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,276 @@
+{
+  "name": "safe-json-stringify",
+  "version": "1.0.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/repository/npm-all/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "http://npm.paypal.com/repository/npm-all/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "http://npm.paypal.com/repository/npm-all/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/repository/npm-all/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "http://npm.paypal.com/repository/npm-all/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/repository/npm-all/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.8.0",
+      "resolved": "http://npm.paypal.com/repository/npm-all/es-abstract/-/es-abstract-1.8.0.tgz",
+      "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.0",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "http://npm.paypal.com/repository/npm-all/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "http://npm.paypal.com/repository/npm-all/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "http://npm.paypal.com/repository/npm-all/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/repository/npm-all/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.0",
+      "resolved": "http://npm.paypal.com/repository/npm-all/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "http://npm.paypal.com/repository/npm-all/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/repository/npm-all/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "http://npm.paypal.com/repository/npm-all/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "http://npm.paypal.com/repository/npm-all/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "http://npm.paypal.com/repository/npm-all/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/repository/npm-all/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/repository/npm-all/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "http://npm.paypal.com/repository/npm-all/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/repository/npm-all/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "http://npm.paypal.com/repository/npm-all/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "http://npm.paypal.com/repository/npm-all/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.2.2",
+      "resolved": "http://npm.paypal.com/repository/npm-all/object-inspect/-/object-inspect-1.2.2.tgz",
+      "integrity": "sha1-yCEV5PzIiK6hTWTCLk8X9qcNXlo=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "http://npm.paypal.com/repository/npm-all/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "http://npm.paypal.com/repository/npm-all/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/repository/npm-all/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "http://npm.paypal.com/repository/npm-all/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "http://npm.paypal.com/repository/npm-all/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "http://npm.paypal.com/repository/npm-all/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.0",
+        "function-bind": "1.1.0"
+      }
+    },
+    "tape": {
+      "version": "4.6.3",
+      "resolved": "http://npm.paypal.com/repository/npm-all/tape/-/tape-4.6.3.tgz",
+      "integrity": "sha1-Y353WB6ass4XV36b1M5PV1gG2LY=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.0",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.2.2",
+        "resolve": "1.1.7",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://npm.paypal.com/repository/npm-all/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "http://npm.paypal.com/repository/npm-all/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/test/safe-json-stringify-test.js
+++ b/test/safe-json-stringify-test.js
@@ -171,3 +171,44 @@ test('enumerable defined getter properties using Object.defineProperty', functio
 		'should return [Throws] when a getter throws an error'
 	);
 });
+
+test('formatting', function(t) {
+	var obj = {a:{b:1, c:[{d: 1}]}}; // some nested object
+	var formatters = [3, "\t", "	"];
+	t.plan(formatters.length)
+	formatters.forEach((formatter) => {
+		t.equal(
+			JSON.stringify(obj, null, formatter),
+			safeJsonStringify(obj, null, formatter),
+			'should apply identical formatting as JSON.stringify itself'
+		);
+		// t.notEqual(
+		// 	safeJsonStringify(obj, null),
+		// 	safeJsonStringify(obj, null, formatter),
+		// 	'should not test trivial identities'
+		// );
+	});
+});
+
+test('replacing', function(t) {
+	var obj = {a:{b:1, c:[{d: 1}]}}; // some nested object
+	var replacers = [
+		["a", "c"],
+		(k, v) => typeof v == 'number' ? "***" : v,
+		() => undefined,
+		[]
+	];
+	t.plan(replacers.length)
+	replacers.forEach((replacer) => {
+		t.equal(
+			JSON.stringify(obj, replacer),
+			safeJsonStringify(obj, replacer),
+			'should use replacer functionality the identical way as JSON.stringify itself'
+		);
+		// t.notEqual(
+		//	 safeJsonStringify(obj, null),
+		//	 safeJsonStringify(obj, replacer),
+		//	 'should not test trivial identities'
+		// );
+	});
+});

--- a/test/safe-json-stringify-test.js
+++ b/test/safe-json-stringify-test.js
@@ -182,11 +182,6 @@ test('formatting', function(t) {
 			safeJsonStringify(obj, null, formatter),
 			'should apply identical formatting as JSON.stringify itself'
 		);
-		// t.notEqual(
-		// 	safeJsonStringify(obj, null),
-		// 	safeJsonStringify(obj, null, formatter),
-		// 	'should not test trivial identities'
-		// );
 	});
 });
 
@@ -205,10 +200,5 @@ test('replacing', function(t) {
 			safeJsonStringify(obj, replacer),
 			'should use replacer functionality the identical way as JSON.stringify itself'
 		);
-		// t.notEqual(
-		//	 safeJsonStringify(obj, null),
-		//	 safeJsonStringify(obj, replacer),
-		//	 'should not test trivial identities'
-		// );
 	});
 });


### PR DESCRIPTION
safe-json-stringify currently doesn't support the formatting and replacement functions that `JSON.stringify` provides. Since the module uses `JSON.stringify` for the actual serialization, it is easy to accept and proxy the missing parameters.

Also added tests and a remark in the docs.