### PR TITLE
Fix detection of circular references as opposed to object identity

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,21 +32,27 @@ function ensureProperties(obj) {
 
 		if (typeof obj.toJSON === 'function') {
 			try {
-				return visit(obj.toJSON());
+				var fResult = visit(obj.toJSON());
+				seen.pop();
+				return fResult;
 			} catch(err) {
 				return throwsMessage(err);
 			}
 		}
 
 		if (Array.isArray(obj)) {
-			return obj.map(visit);
+			var aResult = obj.map(visit);
+			seen.pop();
+			return aResult;
 		}
 
-		return Object.keys(obj).reduce(function(result, prop) {
+		var result = Object.keys(obj).reduce(function(result, prop) {
 			// prevent faulty defined getter properties
 			result[prop] = visit(safeGetValueFromPropertyOnObject(obj, prop));
 			return result;
 		}, {});
+		seen.pop();
+		return result;
 	};
 
 	return visit(obj);

--- a/test/safe-json-stringify-test.js
+++ b/test/safe-json-stringify-test.js
@@ -8,6 +8,14 @@ test('basic stringify', function(t) {
 	t.equal('{"foo":"bar"}', safeJsonStringify({foo: 'bar'}), 'a simple object');
 });
 
+test('object identity', function(t) {
+	t.plan(1);
+
+	var a = { foo: 'bar' };
+	var b = { one: a, two: a };
+	t.equal('{"one":{"foo":"bar"},"two":{"foo":"bar"}}',safeJsonStringify(b),'an object with identical properties');
+});
+
 test('circular references', function(t) {
 	t.plan(2);
 


### PR DESCRIPTION
The `seen` stack is now popped as we leave each property, thus only identical objects within a property will flag the circular reference detection, as opposed to any sighting of the same object anywhere in the graph.