### PR TITLE
Stringify BigInts

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ function ensureProperties(obj) {
 	var seen = [ ]; // store references to objects we have seen before
 
 	function visit(obj) {
+		if (typeof obj === 'bigint') {
+			return obj.toString();
+		}
+		
 		if (obj === null || typeof obj !== 'object') {
 			return obj;
 		}


### PR DESCRIPTION
I ran into issues using https://github.com/trentm/node-bunyan which makes use of this library.

This PR simply converts BigInts to strings, which I think is reasonable because 
```
> BigInt('11111111111111111111111111111111111');
11111111111111111111111111111111111n
```

BigNumber.js similarly uses strings as an intermediate representation.